### PR TITLE
Add a package to test if R is installed in environment

### DIFF
--- a/packages/conf-R/conf-R.1/descr
+++ b/packages/conf-R/conf-R.1/descr
@@ -1,0 +1,2 @@
+Virtual package relying on an R installation.
+This package can only install if the R interpreter is available on the system.

--- a/packages/conf-R/conf-R.1/opam
+++ b/packages/conf-R/conf-R.1/opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "leonidr@gmail.com"
+homepage: "https://www.r-project.org/"
+license: "GPL"
+build: [
+  ["R" "-e" "print('R is installed')"]
+]
+depexts: [
+  [["debian"] ["R"]]
+  [["ubuntu"] ["R"]]
+  [["osx"] ["R"]]
+]


### PR DESCRIPTION
This is a virtual package, it is just a dummy to make sure that an `R` executable is installed, ala the `conf-python` package in the master opam. For the purposes of `seq2HLA` no `R` is specified (it is implied it is something modern), so this won't be the best possible way of ensuring that the 'right' `R` is installed, but this is significantly better than not having it. The version, `1` is really an indicator of the version of this script not `R` itself.
