### PR TITLE
Add seq2HLA

### DIFF
--- a/packages/seq2HLA/seq2HLA.2.2/descr
+++ b/packages/seq2HLA/seq2HLA.2.2/descr
@@ -1,0 +1,7 @@
+HLA typing
+
+We developed an in-silico method "Seq2HLA", written in python and R, which takes
+standard RNA-Seq sequence reads in fastq format as input, uses a bowtie index
+comprising all HLA alleles and outputs the most likely HLA class I and class II
+genotypes (in 4 digit resolution), a p-value for each call, and the expression
+of each class.

--- a/packages/seq2HLA/seq2HLA.2.2/files/opam-install.sh
+++ b/packages/seq2HLA/seq2HLA.2.2/files/opam-install.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -e
+
+# The opam lists the following as depext
+# 1. Python 2.7   - necessary for pyinstaller below and checked via conf-python-2.7
+# 2. R            - checked via conf-R
+# 3. pyinstaller  - 'checked' by failing below
+
+LIB=$1/seq2HLA
+BIN=$2
+INSTALLED_LIB=$LIB/dist/seq2HLA
+
+# patch the hardcoded paths to point at the future dir
+sed -i.bak "s|os.path.abspath(os.path.dirname(sys.argv\[0\]))|\"$INSTALLED_LIB\"|g" seq2HLA.py
+sed -i.bak "s|os.path.abspath(os.path.dirname(sys.argv\[0\]))|\"$INSTALLED_LIB\"|g" fourdigits.py
+
+# Catch the stderr to see if Bio is not installed
+pyinstaller --onedir --log-level ERROR --hidden-import Bio seq2HLA.py 2>install.log
+if grep Bio install.log ; then
+  echo "Make sure that Biopython is installed" 1>&2 
+  exit 1
+fi
+
+mkdir -p $LIB
+cp -r dist $LIB
+
+# Copy the R, and other reference file since pyinstaller can't see these scripts
+cp *.R *.dbmhc $INSTALLED_LIB
+cp -R references $INSTALLED_LIB
+ln -s $INSTALLED_LIB/seq2HLA $BIN/seq2HLA

--- a/packages/seq2HLA/seq2HLA.2.2/files/opam-remove.sh
+++ b/packages/seq2HLA/seq2HLA.2.2/files/opam-remove.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+LIB=$1
+BIN=$2
+rm -rf $LIB/seq2HLA
+rm -rf $BIN/seq2HLA

--- a/packages/seq2HLA/seq2HLA.2.2/opam
+++ b/packages/seq2HLA/seq2HLA.2.2/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+name: "seq2HLA"
+version: "2.2"
+authors: "Sebastian Boegel <boegels@uni-mainz.de>"
+license: "MIT"
+tags: ["biology"]
+
+# Nothing to build, seq2HLA is just a script
+build: []
+install: ["./opam-install.sh" "%{lib}%" "%{bin}%"]
+remove:  ["./opam-remove.sh"  "%{lib}%" "%{bin}%"]
+depends: [
+	"conf-python-2-7"
+	"conf-R"
+]
+depexts: [
+  [["ubuntu"] ["python" "R" "pyinstaller"]]
+  [["debian"] ["python" "R" "pyinstaller"]]
+  [["osx"] ["python" "R" "pyinstaller"]]
+]
+
+homepage: "https://bitbucket.org/sebastian_boegel/seq2hla"
+dev-repo: "https://bitbucket.org/sebastian_boegel/seq2hla"
+bug-reports: "https://bitbucket.org/sebastian_boegel/seq2hla/issues"
+post-messages: [ "seq2HLA has been wrapped into a custom exec."  {success} ]
+
+maintainer: "Leonid Rozenberg <leonidr@gmail.com>"

--- a/packages/seq2HLA/seq2HLA.2.2/url
+++ b/packages/seq2HLA/seq2HLA.2.2/url
@@ -1,0 +1,2 @@
+archive: "https://bitbucket.org/hammerlab/seq2hla/get/tip.tar.gz"
+checksum: "35ba6ccfb132dd7be3f72985a337c4d7"


### PR DESCRIPTION
Seq2HLA is a python script to deterine HLA type based on RNAseq reads.
The installation creates a standalone executible using pyinstaller, and
checks to make sure the user has biopython installed. It depends on
Python2.7, R and pyinstaller.