### PR TITLE
Document the OptiType install.

### DIFF
--- a/packages/optitype/optitype.1.0.0/files/OptiTypePipeline.spec
+++ b/packages/optitype/optitype.1.0.0/files/OptiTypePipeline.spec
@@ -13,6 +13,9 @@ a = Analysis(['OptiTypePipeline.py'],
              win_private_assemblies=False,
              cipher=block_cipher)
 
+# Pyinstaller will silently ignore missing dependencies. To avoid having the
+# install script succeed, while the result won't run, we check for the required
+# packages here.
 packages = map(lambda x: x[0], a.pure)
 
 def check_package(module_name):

--- a/packages/optitype/optitype.1.0.0/files/README.md
+++ b/packages/optitype/optitype.1.0.0/files/README.md
@@ -1,0 +1,10 @@
+There are several files used as part of the `pyinstaller` conversion into a
+standalone executable:
+
+  - `OptiTypePipeline.spec` provides the full recipe of how to build Optitype.
+    It ensures and fails proactively if necessary dependencies (`numpy`, `pysam`
+    ..etc) are missing from the environment.
+  - `hook-numpy.py`, `hook-pyomo.py` and `hook-pysam.py` are extra
+    modifications that make sure that `hidden` dependencies of those respective
+    packages are installed.
+  - `optitype.install` - copies over the necessary data and config files.

--- a/packages/optitype/optitype.1.0.0/opam
+++ b/packages/optitype/optitype.1.0.0/opam
@@ -12,19 +12,25 @@ depends: [
   "conf-HDF5"
 ]
 depexts: [
-  [["ubuntu"] ["python" "pyomo" "h5ls"]]
-  [["debian"] ["python" "pyomo" "h5ls"]]
-  [["osx"] ["python" "pyomo" "h5ls"]]
+  [["ubuntu"] ["python" "pyinstaller" "pyomo" ]]
+  [["debian"] ["python" "pyinstaller" "pyomo" ]]
+  [["osx"] ["python" "pyinstaller" "pyomo" ]]
 ]
 
 homepage: "https://github.com/FRED-2/OptiType"
 dev-repo: "https://github.com/FRED-2/OptiType.git"
 bug-reports: "https://github.com/FRED-2/OptiType/issues"
+messages: [
+  "Trying to create an OptiTypePipeline executable, will check for the"
+  "following dependencies: Python2.7, pyinstaller, pyomo and HDF5."
+  ]
 post-messages: [
   "OptiType has been wrapped into a custom exec: OptiTypePipeline."  {success}
   "An example config file (config.ini.example) that is needed in for running OptiTypePipeline," {success}
   "DNA and RNA reference fasta's, and an HDF5 lib of the alleles is in" {success}
-  "`opam config var lib`/optitype." {success}
+  "`opam config var lib`/optitype. Therefore, when you wish to run OptiTypePipeline:" {success}
+  "cp -r `opam config var lib`/optitype/data . && cp -r `opam config var lib`/optitype/config.ini.example config.ini`," {success}
+  "in your work directory." {success}
 ]
 
 maintainer: "Leonid Rozenberg <leonidr@gmail.com>"


### PR DESCRIPTION
@agarwal As per previous commit, here is some documentation.

I agree that `OptiTypePipeline.spec` is growing out of hand. It is a requirement (self-enforced and perhaps the wrong one) of trying to create these standalone executables. I find it valuable to have this modularity with these Python scripts, I know that it will run and won't get into `$PYTHONPATH` hell or even having the wrong version on `$PATH`. But on the other hand a point can be made that I should just contribute to the upstream package. I initially thought that using `pyinstaller` would be an experiment, and that a consensus would emerge as whether this is a good or bad technique. Presently, I strongly feel that it is cumbersome, but I don't know what else to try.