### PR TITLE
Opam version 1.2 determines proper man page dir

### DIFF
--- a/packages/samtools/samtools.1.2/files/samtools.install
+++ b/packages/samtools/samtools.1.2/files/samtools.install
@@ -22,6 +22,4 @@ bin: [
   "misc/zoom2sam.pl"
 ]
 
-man: [
-  "samtools.1" {"man/man1"}
-]
+man: [ "samtools.1" ]


### PR DESCRIPTION
I'm not certain if this an `opam` issue that changed.